### PR TITLE
Include Makefile. Contains non-existent targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+CXX 	:= g++
+DEBUG 	:= # -g
+OPT	:= -O2
+
+COMP 	:= $(CXX) $(DEBUG) $(OBJS) -c
+
+OBJS 	:= airplane.o boat.o car.o config.o quadcopter.o robosim.o \
+		submarine.o tank.o vec_3d.o world.o
+
+robosim : $(OBJS)
+	  $(CXX) $(DEBUG) $(OBJS) -o robosim
+
+airplane.o 	: airplane.cc airplane.hh
+			$(COMP) $<
+
+boat.o		: boat.cc boat.hh
+			$(COMP) $<
+
+car.o		: car.cc car.hh	
+			$(COMP) $<
+
+quadcopter.o 	: quadcopter.cc quadocopter.hh
+			$(COMP) $<
+
+submarine.o 	: submarine.cc submarine.hh
+			$(COMP) $<
+
+robosim.o	: robosim.cc robosim.hh
+			$(COMP) $<
+
+submarine.o	: submarine.cc submarine.hh
+			$(COMP) $<
+
+tank.o		: tank.cc tank.hh
+			$(COMP) $<
+
+vec_3d.o	: vec_3d.cc vec_3d.hh
+			$(COMP) $<
+
+world.o		: world.cc world.hh
+			$(COMP) $<
+
+clean		: 
+			rm  $(OBJS) robosim


### PR DESCRIPTION
The Makefile contains all targets presented in class. In its current state it does not build the project, because some files are missing. It would be nice to rely mostly on variables defined e.g. as OBJS, then deduct target name and source files.